### PR TITLE
Update to abstract 0.13.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,23 +27,23 @@ keywords = ["integration", "testing", "CosmWasm"]
 cosmwasm-std = { version = "1.1.9" }
 cosmwasm-schema = { version = "1.1.9" }
 cw-storage-plus = "1.0.1"
-cw20-base = { version = "1.0.1" }
-cw20 = { version = "1.0.1" }
+cw20-base = { git = "https://github.com/Abstract-OS/cw-plus.git" }
+cw20 = { git = "https://github.com/Abstract-OS/cw-plus.git" }
 
 cw-asset = { version = "3.0" }
 
 cw-semver = { version = "1.0"}
-boot-core = { version = "0.8.0" }
-boot-cw-plus = { version = "0.8.0" }
+boot-core = { git = "https://github.com/Abstract-OS/BOOT.git" }
+boot-cw-plus = { git = "https://github.com/Abstract-OS/BOOT.git" }
 
-abstract-macros = {version = "0.11" }
-abstract-ica = { version = "0.11" }
-abstract-os = { version = "0.12" }
-abstract-sdk = { version = "0.12" }
-abstract-app = { version = "0.12" }
-abstract-api = { version = "0.12" }
-abstract-ibc-host = { version = "0.11" }
-abstract-boot = {version = "0.12" }
+abstract-macros = {version = "0.13.2" }
+abstract-ica = { version = "0.13.2" }
+abstract-core = { version = "0.13.2" }
+abstract-sdk = { version = "0.13.2" }
+abstract-app = { version = "0.13.2" }
+abstract-api = { version = "0.13.2" }
+abstract-ibc-host = { version = "0.13.2" }
+abstract-boot = {version = "0.13.2" }
 
 ## Testing
 cw-multi-test = { version = "0.16.2" }

--- a/bundles/wyndex/Cargo.toml
+++ b/bundles/wyndex/Cargo.toml
@@ -19,7 +19,7 @@ cw20-base = { workspace = true }
 cw20 = { workspace = true }
 boot-core = { workspace = true }
 boot-cw-plus = { workspace = true }
-abstract-os = { workspace = true }
+abstract-core = { workspace = true }
 abstract-boot = { workspace = true, features = ["integration"] }
 cosmwasm-std = { workspace = true }
 cosmwasm-schema = { workspace = true }

--- a/bundles/wyndex/src/suite.rs
+++ b/bundles/wyndex/src/suite.rs
@@ -3,7 +3,7 @@ use std::cell::RefMut;
 
 use anyhow::Result as AnyResult;
 
-use boot_core::{Mock, StateInterface};
+use abstract_boot::boot_core::{Mock, StateInterface};
 use cosmwasm_schema::serde::Serialize;
 use cosmwasm_std::{coin, to_binary, Addr, Coin, Decimal, Uint128};
 use cw20::{BalanceResponse, Cw20ExecuteMsg, Cw20QueryMsg};

--- a/bundles/wyndex/tests/abstract.rs
+++ b/bundles/wyndex/tests/abstract.rs
@@ -2,7 +2,7 @@ use cosmwasm_std::Addr;
 
 mod abstrct {
     use abstract_boot::Abstract;
-    use boot_core::{instantiate_default_mock_env, Deploy};
+    use abstract_boot::boot_core::{instantiate_default_mock_env, Deploy};
     use cosmwasm_std::Empty;
 
     use wyndex_bundle::{WynDex, WYNDEX_OWNER};

--- a/bundles/wyndex/tests/staking.rs
+++ b/bundles/wyndex/tests/staking.rs
@@ -8,7 +8,7 @@ use wyndex_stake::msg::{QueryMsg as StakeQueryMsg, ReceiveDelegationMsg, StakedR
 use wyndex_stake::state::Config as WyndexStakeConfig;
 
 mod staking {
-    use boot_core::instantiate_default_mock_env;
+    use abstract_boot::boot_core::instantiate_default_mock_env;
     use wyndex::factory::{DefaultStakeConfig, DistributionFlow};
     use wyndex_bundle::{suite::SuiteBuilder, WYNDEX_OWNER};
 

--- a/bundles/wyndex/tests/swap.rs
+++ b/bundles/wyndex/tests/swap.rs
@@ -1,4 +1,4 @@
-use boot_core::instantiate_default_mock_env;
+use abstract_boot::boot_core::instantiate_default_mock_env;
 use cosmwasm_std::{coin, testing::mock_env, Addr};
 use wyndex::asset::{AssetInfo, AssetInfoExt};
 use wyndex_bundle::suite::SuiteBuilder;


### PR DESCRIPTION
This change updates the integration bundles to use abstract:0.13.2.

It also fixes some issues with the new boot-cw-plus version (such as the removal of "create_new").